### PR TITLE
Isolates package creation in Docker builds from worksystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install gunicorn
 COPY . /code
 WORKDIR /code
-RUN python setup.py sdist\
-  && pip install dist/*
+RUN DIST_DIR=$(mktemp -d) && python setup.py sdist --dist-dir $DIST_DIR\
+  && pip install $DIST_DIR/*.tar.gz
 
 
 FROM $PYTHON_BASE 


### PR DESCRIPTION
Place sdist output into tmp directory to avoid problem pip installs on developer systems.