### PR TITLE
fix: Make extras_require actually get used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1 (2019-08-23)
+
+* Added extras_require for aws_lambda
+
 ## 0.1.0 (2019-08-22)
 
 * Add aws lambda handler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## 0.1.1 (2019-08-23)
 
-* Added extras_require for aws_lambda
+  * Added extras_require for aws_lambda
 
 ## 0.1.0 (2019-08-22)
 
-* Add aws lambda handler
-* Clean up code to contain state better (for lambda compatability)
+  * Add aws lambda handler
+  * Clean up code to contain state better (for lambda compatability)
 
 ## 0.0.1-dev (2019-07-05)
 
-* First release on PyPI.
+  * First release on PyPI.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ any guide on configuring Flask servers for deployment. A Dockerfile pre-configur
 
 ### AWS Lambda Support
 
-The application can be run in AWS Lambda by using the `handler` function in the `aws_lambda` module.
+The application can be run in AWS Lambda by using the `handler` function in the `aws_lambda` module. In this case it should be installed with the
+`aws_lambda` optional dependencies, i.e. `pip install ebr-board['aws_lambda']`.
 It expects that the configuration (the main configuration, vault configuration and vault creds) will be stored entirely as strings in the parameter
 store. The way it processes these parameters can be configured with environmental variables:
 * `config_name`: defaults to `ebr_board_config`

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ requirements = [
     "PyYAML>=5.1,<6",
 ]
 
-extra_requirements = {"aws_lambda": ["aws-wsgi>=0.2.0", "ssm-parameter-store>=19.5.0,<20.0.0"]}
+extras_require = {"aws_lambda": ["aws-wsgi>=0.2.0", "ssm-parameter-store>=19.5.0,<20.0.0"]}
 
 # Ensure that linting and testing will be done with all depedencies installed
 collected_extras = []
-for req_set in extra_requirements.values():
+for req_set in extras_require.values():
     collected_extras += req_set
 
 setup_requirements = ["pytest-runner"] + collected_extras
@@ -64,6 +64,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite="tests",
     tests_require=test_requirements,
+    extras_require=extras_require,
     url="https://github.com/tomtom-international/ebr-board",
     version=ebr_board.__version__,
     zip_safe=False,


### PR DESCRIPTION
Previous PR overlooked setting the extras_requires (even though the dictionary existed).
This is required for aws_lambda.