### PR TITLE
chore: Drop Python 3.5 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.2.0 (2019-08-26)
+  * Removed support for Python 3.5
+
 ## 0.1.1 (2019-08-23)
 
   * Added extras_require for aws_lambda

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## 0.2.0 (2019-08-26)
-  * Removed support for Python 3.5
+
+* Removed support for Python 3.5
 
 ## 0.1.1 (2019-08-23)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,3 +17,8 @@ jobs:
   - template: jobs/python.setup.py.yml@templates
     parameters:
       pypiConnector: "pypi-tomtom"
+      pythonTestVersions:
+      - name: Python36
+        version: "3.6"
+      - name: Python37
+        version: "3.7"

--- a/ebr_board/__init__.py
+++ b/ebr_board/__init__.py
@@ -5,4 +5,4 @@
 __project__ = "ebr-board"
 __author__ = "Eugene Davis"
 __email__ = "eugene.davis@tomtom.com"
-__version__ = "0.1.2-dev"
+__version__ = "0.2.0-dev"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2-dev
+current_version = 0.2.0-dev
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-zA-Z]+))?

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],


### PR DESCRIPTION
Dropping Python 3.5 due to its lack of features in testing.
Support for 3.5 has already been dropped in the main down-stream consumer, [ebr-trackerbot](https://github.com/tomtom-international/ebr-trackerbot)