### PR TITLE
feat: Make URL prefix configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ elastic:
 
 ```
 
+To change the default url prefix (`/api`) add a new key-value at the top level:
+```yaml
+url_prefix: "/new_prefix"
+```
+
+To have *no* prefix, provide an empty string, i.e.
+```yaml
+url_prefix: ""`
+```
+
 
 ### Dev Mode
 

--- a/ebr_board/app.py
+++ b/ebr_board/app.py
@@ -41,7 +41,7 @@ def create_app(  # pylint: disable=too-many-arguments
     app = Flask(__name__)  # pylint: disable=invalid-name
     app.config.from_object(config)
 
-    api_bp = Blueprint("api", __name__, url_prefix="/api")
+    api_bp = Blueprint("api", __name__, url_prefix=config.get("url_prefix", "/api"))
     configure_api(api_bp)
 
     with app.app_context():

--- a/ebr_board/config.py
+++ b/ebr_board/config.py
@@ -30,12 +30,12 @@ class VaultConfig:  # pylint: disable=too-many-instance-attributes,too-few-publi
         config_client = VaultAnyConfig(vault_config, ac_parser=config_format)
         config_client.auto_auth(vault_creds, ac_parser=config_format)
         if os.path.isfile(config):
-            config = config_client.load(config, process_secret_files=load_certs)
+            self.config = config_client.load(config, process_secret_files=load_certs)
         else:
-            config = config_client.loads(config, process_secret_files=load_certs, ac_parser=config_format)
+            self.config = config_client.loads(config, process_secret_files=load_certs, ac_parser=config_format)
 
         # Elastic Search
-        elastic_config = config["elastic"]
+        elastic_config = self.config["elastic"]
         self.connect_elastic(elastic_config)
         self.ES_INDEX = elastic_config["index"]
 
@@ -62,3 +62,13 @@ class VaultConfig:  # pylint: disable=too-many-instance-attributes,too-few-publi
 
         local_src_config.update({"http_auth": user + ":" + password})
         connections.create_connection(hosts=[local_src_config])
+
+    def get(self, key, default=None):
+        """
+        Passes through to the config dictionary
+        Args:
+            key: key to retrieve from config
+            default: (optional) default value
+        """
+
+        return self.config.get(key, default)


### PR DESCRIPTION
Rather than hardcoding the URL prefix to `/api` this allows configuring the prefix in the configuration file.